### PR TITLE
Use github accesskey when calling github api's and clones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bookbinder*.gem
 Gemfile.lock
 .bundle
 file_modification_dates
+.idea/

--- a/lib/bookbinder/repository.rb
+++ b/lib/bookbinder/repository.rb
@@ -55,9 +55,16 @@ module Bookbinder
     end
 
     def copy_from_remote(destination_dir, git_accessor = Git)
-      @git = git_accessor.clone("git@github.com:#{full_name}", directory, path: destination_dir)
+      url = get_repo_url(@full_name)
+      @git = git_accessor.clone(url, directory, path: destination_dir)
       @git.checkout(target_ref) unless target_ref == 'master'
       @copied_to = destination_dir
+    end
+    
+    def get_repo_url(name)
+      repo = @github.repository(name)
+      url = repo.rels[:clone].href
+      url.sub('://', "://#{@github.access_token}:x-oauth-basic@") unless @github.access_token.nil? or @github.access_token.empty?
     end
 
     def copy_from_local(destination_dir)

--- a/spec/bookbinder_helpers_spec.rb
+++ b/spec/bookbinder_helpers_spec.rb
@@ -19,8 +19,11 @@ module Bookbinder
       end
     end
 
+    let(:github) {"https://#{ENV['GITHUB_API_TOKEN']}:x-oauth-basic@github.com"}
+
     before do
       allow(BookbinderLogger).to receive(:new).and_return(logger)
+      allow_any_instance_of(Repository).to receive(:get_repo_url) { |o, name | "#{github}/#{name}"}
     end
 
     def run_middleman(template_variables = {}, subnav_templates = {})

--- a/spec/code_example_spec.rb
+++ b/spec/code_example_spec.rb
@@ -7,6 +7,11 @@ module Bookbinder
       let(:logger) { NilLogger.new }
       let(:git_client) { GitClient.new(logger) }
       let(:code_example) { CodeExample.get_instance(logger, section_hash: {'repository' => {'name' => repo_name}}, git_accessor: SpecGitAccessor) }
+      let(:github) {"https://#{ENV['GITHUB_API_TOKEN']}:x-oauth-basic@github.com"}
+
+      before do
+        allow_any_instance_of(Repository).to receive(:get_repo_url) { |o, name | "#{github}/#{name}"}
+      end
 
       it 'produces a string for the given excerpt_marker' do
         code_snippet = <<-RUBY

--- a/spec/commands/publish_spec.rb
+++ b/spec/commands/publish_spec.rb
@@ -106,6 +106,11 @@ module Bookbinder
 
     context 'github' do
       let(:zipped_repo_url) { "https://github.com/#{book}/archive/master.tar.gz" }
+      let(:github) {"https://#{ENV['GITHUB_API_TOKEN']}:x-oauth-basic@github.com"}
+
+      before do
+        allow_any_instance_of(Repository).to receive(:get_repo_url) { |o, name | "#{github}/#{name}"}
+      end
 
       it 'creates some static HTML' do
         publish_command.run(['github'], SpecGitAccessor)

--- a/spec/credential_provider_spec.rb
+++ b/spec/credential_provider_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 module Bookbinder
   describe CredentialProvider do
     describe '#credentials' do
+
+
       subject(:credentials) do
         CredentialProvider.new logger, credentials_repository, SpecGitAccessor
       end
@@ -14,6 +16,11 @@ module Bookbinder
       let(:full_name) { 'org-name/creds-repo' }
       let(:credentials_repository) do
         Repository.new(logger: logger, full_name: 'org-name/creds-repo')
+      end
+      let(:github) {"https://#{ENV['GITHUB_API_TOKEN']}:x-oauth-basic@github.com"}
+
+      before do
+        allow_any_instance_of(Repository).to receive(:get_repo_url) { |o, name | "#{github}/#{name}"}
       end
 
       it 'returns a hash of the credentials in credentials.yml' do

--- a/spec/publisher_spec.rb
+++ b/spec/publisher_spec.rb
@@ -12,6 +12,7 @@ module Bookbinder
       let(:non_broken_master_middleman_dir) { generate_middleman_with 'non_broken_index.html' }
       let(:dogs_master_middleman_dir) { generate_middleman_with 'dogs_index.html' }
       let(:git_client) { GitClient.new(logger) }
+      let(:github) {"https://#{ENV['GITHUB_API_TOKEN']}:x-oauth-basic@github.com"}
 
       context 'integration' do
         before do
@@ -19,6 +20,7 @@ module Bookbinder
           allow(BookbinderLogger).to receive(:new).and_return(NilLogger.new)
           allow(ProgressBar).to receive(:create).and_return(double(increment: nil))
           WebMock.disable_net_connect!(:allow_localhost => true)
+          allow_any_instance_of(Repository).to receive(:get_repo_url) { |o, name | "#{github}/#{name}"}
         end
 
         after { WebMock.disable_net_connect! }
@@ -32,11 +34,11 @@ module Bookbinder
           some_sha = 'some-sha'
           some_other_sha = 'some-other-sha'
 
-          expect(SpecGitAccessor).to receive(:clone).with("git@github.com:#{some_repo}",
+          expect(SpecGitAccessor).to receive(:clone).with("#{github}/#{some_repo}",
                                               "pretty_path",
                                               anything).and_call_original
 
-          expect(SpecGitAccessor).to receive(:clone).with("git@github.com:#{some_other_repo}",
+          expect(SpecGitAccessor).to receive(:clone).with("#{github}/#{some_other_repo}",
                                              File.basename(some_other_repo),
                                              anything).and_call_original
           sections = [
@@ -156,10 +158,10 @@ module Bookbinder
           end
 
           it 'applies the syntax highlighting CSS' do
-            expect(SpecGitAccessor).to receive(:clone).with("git@github.com:#{section_repo_name}",
+            expect(SpecGitAccessor).to receive(:clone).with("#{github}/#{section_repo_name}",
                                                             File.basename(section_repo_name),
                                                             anything).and_call_original
-            expect(SpecGitAccessor).to receive(:clone).with("git@github.com:#{code_repo}",
+            expect(SpecGitAccessor).to receive(:clone).with("#{github}/#{code_repo}",
                                                             File.basename(code_repo),
                                                             anything).and_call_original
 
@@ -188,10 +190,10 @@ module Bookbinder
           end
 
           it 'makes only one request per code example repository' do
-            expect(SpecGitAccessor).to receive(:clone).with("git@github.com:org/dogs-repo",
+            expect(SpecGitAccessor).to receive(:clone).with("#{github}/org/dogs-repo",
                                                             "dogs-repo",
                                                             anything).and_call_original
-            expect(SpecGitAccessor).to receive(:clone).with("git@github.com:cloudfoundry/code-example-repo",
+            expect(SpecGitAccessor).to receive(:clone).with("#{github}/cloudfoundry/code-example-repo",
                                                             "code-example-repo",
                                                             anything).and_call_original
 

--- a/spec/section_spec.rb
+++ b/spec/section_spec.rb
@@ -7,11 +7,13 @@ module Bookbinder
 
     describe '.get_instance' do
       let(:local_repo_dir) { '/dev/null' }
+      let(:github) {"https://#{ENV['GITHUB_API_TOKEN']}:x-oauth-basic@github.com"}
 
       before do
-        allow(Git).to receive(:clone).with("git@github.com:foo/book",
+        allow(Git).to receive(:clone).with("#{github}/foo/book",
                                             'book',
                                             anything)
+        allow_any_instance_of(Repository).to receive(:get_repo_url) { |o, name | "#{github}/#{name}"}
       end
 
       context 'when called more than once' do


### PR DESCRIPTION
I ran into issues where I could not pull down our private creds repo (docs-pcfp-site-credentials) when I ran push_local_to_staging. With this change we send the GITHUB_API_TOKEN (personal access key) in the url according to github docs. The clone URI is now assumed to be https instead of git. I'm not sure this is the "right" way to fix this issue, but worked for my needs. It feels weird to change git to https, but there are probably other reasons why that might be good (firewalls), so I didn't sweat it too much. Please advise if I should go about this a different way and I'll take another shot. 

Here's a before and after well as a test run: 

```
➜  docs-book-pcfp git:(master) ✗ bundle exec bookbinder push_local_to_staging                                                                                                                
Processing pivotal-cf/docs-pcfp-site-credentials
git clone '--' 'git@github.com:pivotal-cf/docs-pcfp-site-credentials' '/var/folders/44/kxt0zwwx12bb7vkcznnd7_8m0000gp/T/d20141124-8557-1ms722l/docs-pcfp-site-credentials'  2>&1:Cloning into '/var/folders/44/kxt0zwwx12bb7vkcznnd7_8m0000gp/T/d20141124-8557-1ms722l/docs-pcfp-site-credentials'...
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights and the repository exists.
➜  docs-book-pcfp git:(master) ✗ (cd ../bookbinder && git checkout api_tokens )  
Switched to branch 'api_tokens'

➜  docs-book-pcfp git:(master) ✗ bundle exec bookbinder push_local_to_staging  
Processing pivotal-cf/docs-pcfp-site-credentials
API endpoint: https://api.run.pivotal.io
Authenticating...
OK
Targeted org pcfp
....
This URL will expire in 2 hours, so if you need to share it, make sure to save a copy now.

#This is after merging to master, contains changed code
➜  bookbinder git:(master) (cd ../bookbinder && git status && rake )
On branch master
Your branch is ahead of 'upstream/master' by 1 commit.
  (use "git push" to publish your local commits)

nothing to commit, working directory clean
/Users/jkruck/.rvm/rubies/ruby-2.1.1/bin/ruby -I/Users/jkruck/.rvm/gems/ruby-2.1.1/gems/rspec-core-3.1.7/lib:/Users/jkruck/.rvm/gems/ruby-2.1.1/gems/rspec-support-3.1.2/lib /Users/jkruck/.rvm/gems/ruby-2.1.1/gems/rspec-core-3.1.7/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
Run options: exclude {:integration=>true}
........................................................*.......................................................................................................................................................*...................................................................................................................................................*..*....

Pending:
  Bookbinder::MiddlemanRunner behaves like a ShellOut
    # Not yet implemented
    # ./spec/middleman_runner_spec.rb:23
  Sieve#links_from when the page is found and it does not have a valid html body
    # No reason given
    # ./spec/sieve_spec.rb:32
  PdfGenerator generates a PDF from the specified pages and header
    # No reason given
    # ./spec/pdf_generator_spec.rb:20
  PdfGenerator when generating pages from a live web-server generates a PDF from a live web-page and header
    # No reason given
    # ./spec/pdf_generator_spec.rb:34

Finished in 44.46 seconds (files took 2.04 seconds to load)
364 examples, 0 failures, 4 pending

Randomized with seed 57999
```

Thanks, 
Josh
