### PR TITLE
Ignore Vim tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bookbinder*.gem
 Gemfile.lock
 .bundle
 file_modification_dates
+tags


### PR DESCRIPTION
Vim users often leave a 'tags' file in the project root. This commit ignores it so it doesn't get committed.
