### PR TITLE
Make git access generic

### DIFF
--- a/lib/bookbinder/commands/bind.rb
+++ b/lib/bookbinder/commands/bind.rb
@@ -177,19 +177,19 @@ module Bookbinder
       end
 
       def gather_sections(workspace, cloner, ref_override)
-        config.sections.map do |attributes|
+        config.sections.map do |section_config|
           target_ref = ref_override ||
-            attributes.fetch('repository', {})['ref'] ||
+            section_config.fetch('repository', {})['ref'] ||
             'master'
-          repo_name = attributes.fetch('repository').fetch('name')
-          directory = attributes['directory']
-          vcs_repo = cloner.call(from: repo_name,
-                                 ref: target_ref,
-                                 parent_dir: workspace,
-                                 dir_name: directory)
+          repo_name = section_config.fetch('repository').fetch('name')
+          directory = section_config['directory']
+          working_copy = cloner.call(from: repo_name,
+                                     ref: target_ref,
+                                     parent_dir: workspace,
+                                     dir_name: directory)
           @section_repository.get_instance(
-            attributes,
-            working_copy: vcs_repo,
+            section_config,
+            working_copy: working_copy,
             destination_dir: workspace
           ) { |*args| Section.new(*args) }
         end

--- a/lib/bookbinder/commands/bind.rb
+++ b/lib/bookbinder/commands/bind.rb
@@ -189,7 +189,7 @@ module Bookbinder
                                  dir_name: directory)
           @section_repository.get_instance(
             attributes,
-            vcs_repo: vcs_repo,
+            working_copy: vcs_repo,
             destination_dir: workspace
           ) { |*args| Section.new(*args) }
         end

--- a/lib/bookbinder/ingest/cloner_factory.rb
+++ b/lib/bookbinder/ingest/cloner_factory.rb
@@ -4,14 +4,15 @@ require_relative 'local_filesystem_cloner'
 module Bookbinder
   module Ingest
     class ClonerFactory
-      def initialize(logger, version_control_system)
+      def initialize(logger, filesystem, version_control_system)
         @logger = logger
+        @filesystem = filesystem
         @version_control_system = version_control_system
       end
 
       def produce(source, user_repo_dir)
         if user_repo_dir
-          LocalFilesystemCloner.new(logger, version_control_system, user_repo_dir)
+          LocalFilesystemCloner.new(logger, filesystem, user_repo_dir)
         else
           GitHubRepositoryCloner.new(logger, version_control_system)
         end
@@ -19,7 +20,7 @@ module Bookbinder
 
       private
 
-      attr_reader :logger, :version_control_system
+      attr_reader :logger, :filesystem, :version_control_system
     end
   end
 end

--- a/lib/bookbinder/ingest/git_hub_repository_cloner.rb
+++ b/lib/bookbinder/ingest/git_hub_repository_cloner.rb
@@ -19,8 +19,8 @@ module Bookbinder
         WorkingCopy.new(
           copied: repo.copied?,
           copied_to: repo.copied_to,
-          directory: repo.directory,
-          full_name: repo.full_name,
+          directory: dir_name,
+          full_name: from,
         )
       end
 

--- a/lib/bookbinder/ingest/git_hub_repository_cloner.rb
+++ b/lib/bookbinder/ingest/git_hub_repository_cloner.rb
@@ -10,12 +10,18 @@ module Bookbinder
                ref: nil,
                parent_dir: nil,
                dir_name: nil)
-        GitHubRepository.
+        repo = GitHubRepository.
           build_from_remote(logger,
                             {'repository' => {'name' => from},
                              'directory' => dir_name},
                              version_control_system).
                              tap { |repo| repo.copy_from_remote(parent_dir, ref) }
+        WorkingCopy.new(
+          copied: repo.copied?,
+          copied_to: repo.copied_to,
+          directory: repo.directory,
+          full_name: repo.full_name,
+        )
       end
 
       private

--- a/lib/bookbinder/ingest/git_hub_repository_cloner.rb
+++ b/lib/bookbinder/ingest/git_hub_repository_cloner.rb
@@ -17,7 +17,6 @@ module Bookbinder
                              version_control_system).
                              tap { |repo| repo.copy_from_remote(parent_dir, ref) }
         WorkingCopy.new(
-          copied: repo.copied?,
           copied_to: repo.copied_to,
           directory: dir_name,
           full_name: from,

--- a/lib/bookbinder/ingest/local_filesystem_cloner.rb
+++ b/lib/bookbinder/ingest/local_filesystem_cloner.rb
@@ -1,28 +1,30 @@
+require_relative '../deprecated_logger'
 require_relative 'working_copy'
 
 module Bookbinder
   module Ingest
     class LocalFilesystemCloner
-      def initialize(logger, version_control_system, user_repo_dir)
+      def initialize(logger, filesystem, user_repo_dir)
         @logger = logger
-        @version_control_system = version_control_system
         @user_repo_dir = user_repo_dir
+        @filesystem = filesystem
       end
 
       def call(from: nil,
                ref: nil,
                parent_dir: nil,
                dir_name: nil)
-        repo = GitHubRepository.
-          build_from_local(logger,
-                           {'repository' => {'name' => from},
-                            'directory' => dir_name},
-                            user_repo_dir,
-                            version_control_system).
-                            tap { |repo| repo.copy_from_local(parent_dir) }
+        source = WorkingCopy.new(
+          repo_dir: user_repo_dir,
+          directory: dir_name,
+          full_name: from
+        )
+        copied_to = copy!(
+          source,
+          Pathname(parent_dir).join(source.directory)
+        )
         WorkingCopy.new(
-          copied: repo.copied?,
-          copied_to: repo.copied_to,
+          copied_to: copied_to,
           directory: dir_name,
           full_name: from,
         )
@@ -30,7 +32,29 @@ module Bookbinder
 
       private
 
-      attr_reader :logger, :version_control_system, :user_repo_dir
+      attr_reader :logger, :filesystem, :user_repo_dir
+
+      def copy!(source_copy, dest_dir)
+        source_exists = filesystem.file_exist?(source_copy.path)
+
+        if source_exists && filesystem.file_exist?(dest_dir)
+          announce_copy(source_copy)
+          dest_dir
+        elsif source_exists
+          announce_copy(source_copy)
+          filesystem.copy(
+            Pathname("#{source_copy.path}/."),
+            dest_dir
+          )
+          dest_dir
+        else
+          logger.log '  skipping (not found) '.magenta + source_copy.path.to_s
+        end
+      end
+
+      def announce_copy(source_copy)
+        logger.log '  copying '.yellow + source_copy.path.to_s
+      end
     end
   end
 end

--- a/lib/bookbinder/ingest/local_filesystem_cloner.rb
+++ b/lib/bookbinder/ingest/local_filesystem_cloner.rb
@@ -42,10 +42,7 @@ module Bookbinder
           dest_dir
         elsif source_exists
           announce_copy(source_copy)
-          filesystem.copy(
-            Pathname("#{source_copy.path}/."),
-            dest_dir
-          )
+          filesystem.copy_contents(source_copy.path, dest_dir)
           dest_dir
         else
           logger.log '  skipping (not found) '.magenta + source_copy.path.to_s

--- a/lib/bookbinder/ingest/local_filesystem_cloner.rb
+++ b/lib/bookbinder/ingest/local_filesystem_cloner.rb
@@ -23,8 +23,8 @@ module Bookbinder
         WorkingCopy.new(
           copied: repo.copied?,
           copied_to: repo.copied_to,
-          directory: repo.directory,
-          full_name: repo.full_name,
+          directory: dir_name,
+          full_name: from,
         )
       end
 

--- a/lib/bookbinder/ingest/local_filesystem_cloner.rb
+++ b/lib/bookbinder/ingest/local_filesystem_cloner.rb
@@ -1,3 +1,5 @@
+require_relative 'working_copy'
+
 module Bookbinder
   module Ingest
     class LocalFilesystemCloner
@@ -11,13 +13,19 @@ module Bookbinder
                ref: nil,
                parent_dir: nil,
                dir_name: nil)
-        GitHubRepository.
+        repo = GitHubRepository.
           build_from_local(logger,
                            {'repository' => {'name' => from},
                             'directory' => dir_name},
                             user_repo_dir,
                             version_control_system).
                             tap { |repo| repo.copy_from_local(parent_dir) }
+        WorkingCopy.new(
+          copied: repo.copied?,
+          copied_to: repo.copied_to,
+          directory: repo.directory,
+          full_name: repo.full_name,
+        )
       end
 
       private

--- a/lib/bookbinder/ingest/working_copy.rb
+++ b/lib/bookbinder/ingest/working_copy.rb
@@ -13,8 +13,18 @@ module Bookbinder
 
       attr_reader :copied_to, :directory, :full_name
 
+      def directory
+        @directory || short_name
+      end
+
       def copied?
         @copied
+      end
+
+      private
+
+      def short_name
+        full_name.split('/')[1]
       end
     end
   end

--- a/lib/bookbinder/ingest/working_copy.rb
+++ b/lib/bookbinder/ingest/working_copy.rb
@@ -1,0 +1,21 @@
+module Bookbinder
+  module Ingest
+    class WorkingCopy
+      def initialize(copied: nil,
+                     copied_to: nil,
+                     directory: nil,
+                     full_name: nil)
+        @copied = copied
+        @copied_to = copied_to
+        @directory = directory
+        @full_name = full_name
+      end
+
+      attr_reader :copied_to, :directory, :full_name
+
+      def copied?
+        @copied
+      end
+    end
+  end
+end

--- a/lib/bookbinder/ingest/working_copy.rb
+++ b/lib/bookbinder/ingest/working_copy.rb
@@ -1,11 +1,11 @@
 module Bookbinder
   module Ingest
     class WorkingCopy
-      def initialize(copied: nil,
+      def initialize(repo_dir: nil,
                      copied_to: nil,
                      directory: nil,
                      full_name: nil)
-        @copied = copied
+        @repo_dir = repo_dir
         @copied_to = copied_to
         @directory = directory
         @full_name = full_name
@@ -13,12 +13,16 @@ module Bookbinder
 
       attr_reader :copied_to, :directory, :full_name
 
+      def copied?
+        ! copied_to.nil?
+      end
+
       def directory
         @directory || short_name
       end
 
-      def copied?
-        @copied
+      def path
+        Pathname(@repo_dir).join(short_name)
       end
 
       private

--- a/lib/bookbinder/local_file_system_accessor.rb
+++ b/lib/bookbinder/local_file_system_accessor.rb
@@ -44,10 +44,7 @@ module Bookbinder
         FileUtils.mkdir_p(dest)
       end
 
-      contents = Dir.glob File.join(src, '**')
-      contents.each do |dir|
-        FileUtils.cp_r dir, dest
-      end
+      FileUtils.cp_r "#{src}/.", dest
     end
 
     def copy_including_intermediate_dirs(file, root, dest)

--- a/lib/bookbinder/repositories/command_repository.rb
+++ b/lib/bookbinder/repositories/command_repository.rb
@@ -85,7 +85,7 @@ module Bookbinder
           final_app_directory,
           File.absolute_path('.'),
           dita_preprocessor,
-          Ingest::ClonerFactory.new(logger, version_control_system),
+          Ingest::ClonerFactory.new(logger, local_file_system_accessor, version_control_system),
           DitaSectionGathererFactory.new(version_control_system, logger),
           Repositories::SectionRepository.new(logger),
           dita_command_creator,

--- a/lib/bookbinder/repositories/section_repository.rb
+++ b/lib/bookbinder/repositories/section_repository.rb
@@ -7,20 +7,20 @@ module Bookbinder
         @logger = logger
       end
 
-      def get_instance(attributes,
-                       vcs_repo: nil,
+      def get_instance(section_config,
+                       working_copy: nil,
                        destination_dir: Dir.mktmpdir,
                        &build)
-        repository_config = attributes['repository']
+        repository_config = section_config['repository']
         raise "section repository '#{repository_config}' is not a hash" unless repository_config.is_a?(Hash)
         raise "section repository '#{repository_config}' missing name key" unless repository_config['name']
         logger.log "Gathering #{repository_config['name'].cyan}"
-        build[vcs_repo.copied_to,
-              vcs_repo.full_name,
-              vcs_repo.copied?,
-              attributes['subnav_template'],
+        build[working_copy.copied_to,
+              working_copy.full_name,
+              working_copy.copied?,
+              section_config['subnav_template'],
               destination_dir,
-              vcs_repo.directory]
+              working_copy.directory]
       end
 
       private

--- a/master_middleman/bookbinder_helpers.rb
+++ b/master_middleman/bookbinder_helpers.rb
@@ -36,7 +36,7 @@ module Bookbinder
               build_from_remote(bookbinder_logger, attributes, git_accessor).
               tap { |repo| repo.copy_from_remote(workspace, 'master') }
           end
-        example = code_example_repo.get_instance(attributes, vcs_repo: vcs_repo) {
+        example = code_example_repo.get_instance(attributes, working_copy: vcs_repo) {
           |path, name, copied, _, dest, directory|
           CodeExample.new(path, name, copied, dest, directory)
         }

--- a/spec/lib/bookbinder/commands/bind_spec.rb
+++ b/spec/lib/bookbinder/commands/bind_spec.rb
@@ -80,7 +80,7 @@ module Bookbinder
                          partial_args.fetch(:final_app_directory, final_app_dir),
                          partial_args.fetch(:context_dir, File.absolute_path('.')),
                          partial_args.fetch(:dita_preprocessor, dita_preprocessor),
-                         partial_args.fetch(:cloner_factory, Ingest::ClonerFactory.new(logger, SpecGitAccessor)),
+                         partial_args.fetch(:cloner_factory, Ingest::ClonerFactory.new(logger, file_system_accessor, SpecGitAccessor)),
                          DitaSectionGathererFactory.new(bind_version_control_system, bind_logger),
                          Repositories::SectionRepository.new(logger),
                          partial_args.fetch(:command_creator, command_creator),

--- a/spec/lib/bookbinder/ingest/local_filesystem_cloner_spec.rb
+++ b/spec/lib/bookbinder/ingest/local_filesystem_cloner_spec.rb
@@ -1,0 +1,91 @@
+require_relative '../../../../lib/bookbinder/ingest/local_filesystem_cloner'
+
+module Bookbinder
+  module Ingest
+    describe LocalFilesystemCloner do
+      context "when the local repo is present" do
+        let(:null_logger) { double('null logger').as_null_object }
+
+        it "logs the fact that it's copying" do
+          fs = double('filesystem')
+          logger = double('logger')
+
+          allow(fs).to receive(:file_exist?).
+            with(Pathname("/my/repo/dir/myrepo")) { true }
+          allow(fs).to receive(:file_exist?).
+            with(Pathname("/my/dest/myrepo")) { false }
+          allow(fs).to receive(:copy)
+
+          expect(logger).to receive(:log).with(%r{ copying.*/my/repo/dir})
+
+          cloner = LocalFilesystemCloner.new(logger, fs, "/my/repo/dir")
+          cloner.call(from: "myorg/myrepo",
+                      parent_dir: "/my/dest")
+        end
+
+        it "copies the repo to the destination" do
+          fs = double('filesystem')
+
+          allow(fs).to receive(:file_exist?).
+            with(Pathname("/my/repo/dir/myrepo")) { true }
+          allow(fs).to receive(:file_exist?).
+            with(Pathname("/destination/dir/myrepo")) { false }
+
+          expect(fs).to receive(:copy).
+            with(Pathname("/my/repo/dir/myrepo/."),
+                 Pathname("/destination/dir/myrepo"))
+
+          cloner = LocalFilesystemCloner.new(null_logger, fs, "/my/repo/dir")
+          cloner.call(from: "myorg/myrepo",
+                      parent_dir: "/destination/dir")
+        end
+
+        it "returns an object that is #copied?" do
+          fs = double('filesystem')
+
+          allow(fs).to receive(:file_exist?).
+            with(Pathname("/my/repo/dir/myrepo")) { true }
+          allow(fs).to receive(:file_exist?).
+            with(Pathname("/destination/dir/myrepo")) { false }
+          allow(fs).to receive(:copy)
+
+          cloner = LocalFilesystemCloner.new(null_logger, fs, "/my/repo/dir")
+          result = cloner.call(from: "myorg/myrepo",
+                               parent_dir: "/destination/dir")
+
+          expect(result).to be_copied
+        end
+
+        context "but it's already been copied" do
+          it "returns an object that is #copied?, but doesn't perform the copy" do
+            fs = double('filesystem')
+
+            allow(fs).to receive(:file_exist?).
+              with(Pathname("/my/repo/dir/myrepo")) { true }
+            allow(fs).to receive(:file_exist?).
+              with(Pathname("/destination/dir/myrepo")) { true }
+
+            cloner = LocalFilesystemCloner.new(null_logger, fs, "/my/repo/dir")
+            result = cloner.call(from: "myorg/myrepo",
+                                 parent_dir: "/destination/dir")
+
+            expect(result).to be_copied
+          end
+        end
+      end
+
+      context "when the local repo isn't present" do
+        it "logs the fact that it isn't copying anything, and doesn't copy" do
+          fs = double('filesystem', file_exist?: false)
+          logger = double('logger')
+
+          expect(logger).to receive(:log).with(%r{ skipping .*/my/repo/dir})
+
+          cloner = LocalFilesystemCloner.new(logger, fs, "/my/repo/dir")
+          cloner.call(from: "myorg/myrepo",
+                      parent_dir: "/some/dest")
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/bookbinder/ingest/local_filesystem_cloner_spec.rb
+++ b/spec/lib/bookbinder/ingest/local_filesystem_cloner_spec.rb
@@ -85,6 +85,18 @@ module Bookbinder
           cloner.call(from: "myorg/myrepo",
                       parent_dir: "/some/dest")
         end
+
+        it "returns an object that isn't #copied?" do
+          fs = double('filesystem', file_exist?: false)
+          logger = double('logger')
+
+          allow(logger).to receive(:log) { nil } # #log returns nil, because puts returns nil
+
+          cloner = LocalFilesystemCloner.new(logger, fs, "/my/repo/dir")
+          result = cloner.call(from: "myorg/myrepo",
+                               parent_dir: "/some/dest")
+          expect(result).not_to be_copied
+        end
       end
     end
   end

--- a/spec/lib/bookbinder/ingest/local_filesystem_cloner_spec.rb
+++ b/spec/lib/bookbinder/ingest/local_filesystem_cloner_spec.rb
@@ -14,7 +14,7 @@ module Bookbinder
             with(Pathname("/my/repo/dir/myrepo")) { true }
           allow(fs).to receive(:file_exist?).
             with(Pathname("/my/dest/myrepo")) { false }
-          allow(fs).to receive(:copy)
+          allow(fs).to receive(:copy_contents)
 
           expect(logger).to receive(:log).with(%r{ copying.*/my/repo/dir})
 
@@ -31,8 +31,8 @@ module Bookbinder
           allow(fs).to receive(:file_exist?).
             with(Pathname("/destination/dir/myrepo")) { false }
 
-          expect(fs).to receive(:copy).
-            with(Pathname("/my/repo/dir/myrepo/."),
+          expect(fs).to receive(:copy_contents).
+            with(Pathname("/my/repo/dir/myrepo"),
                  Pathname("/destination/dir/myrepo"))
 
           cloner = LocalFilesystemCloner.new(null_logger, fs, "/my/repo/dir")
@@ -47,7 +47,7 @@ module Bookbinder
             with(Pathname("/my/repo/dir/myrepo")) { true }
           allow(fs).to receive(:file_exist?).
             with(Pathname("/destination/dir/myrepo")) { false }
-          allow(fs).to receive(:copy)
+          allow(fs).to receive(:copy_contents)
 
           cloner = LocalFilesystemCloner.new(null_logger, fs, "/my/repo/dir")
           result = cloner.call(from: "myorg/myrepo",

--- a/spec/lib/bookbinder/ingest/working_copy_spec.rb
+++ b/spec/lib/bookbinder/ingest/working_copy_spec.rb
@@ -1,0 +1,15 @@
+require_relative '../../../../lib/bookbinder/ingest/working_copy'
+
+module Bookbinder
+  module Ingest
+    describe WorkingCopy do
+      context "when built without a directory" do
+        it "uses the repo name as the directory" do
+          copy = WorkingCopy.new(directory: nil,
+                                 full_name: "myorg/myrepo")
+          expect(copy.directory).to eq("myrepo")
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/bookbinder/ingest/working_copy_spec.rb
+++ b/spec/lib/bookbinder/ingest/working_copy_spec.rb
@@ -10,6 +10,16 @@ module Bookbinder
           expect(copy.directory).to eq("myrepo")
         end
       end
+
+      it "is copied if copied location is present" do
+        copy = WorkingCopy.new(copied_to: "foo")
+        expect(copy).to be_copied
+      end
+
+      it "isn't copied if copied location is nil" do
+        copy = WorkingCopy.new(copied_to: nil)
+        expect(copy).not_to be_copied
+      end
     end
   end
 end

--- a/spec/lib/bookbinder/local_file_system_accessor_spec.rb
+++ b/spec/lib/bookbinder/local_file_system_accessor_spec.rb
@@ -169,13 +169,15 @@ module Bookbinder
           source_dir_path = File.join tmpdir, 'source_dir'
 
           FileUtils.mkdir_p(dest_dir_path)
-          FileUtils.mkdir_p(source_dir_path)
+          nested_source_dir = File.join(source_dir_path, "some", "nested", "dir")
+          FileUtils.mkdir_p(nested_source_dir)
 
-          filepath = File.join source_dir_path, 'file.txt'
+          filepath = File.join nested_source_dir, 'file.txt'
           File.write filepath, 'this is some text'
 
           expect { fs_accessor.copy_contents source_dir_path, dest_dir_path }.
-              to change{ File.exist? File.join(dest_dir_path, 'file.txt') }.from(false).to(true)
+            to change{ File.exist? File.join(dest_dir_path, "some", "nested", "dir", "file.txt") }.
+            from(false).to(true)
         end
       end
 

--- a/spec/lib/bookbinder/repositories/section_repository_spec.rb
+++ b/spec/lib/bookbinder/repositories/section_repository_spec.rb
@@ -14,18 +14,18 @@ module Bookbinder
         it 'logs the name of the repository' do
           expect(logger).to receive(:log).with(/foo\/book/)
 
-          vcs_repo = double 'vcs_repo', path_to_local_repo: 'path/to/repo', full_name: 'org/repo', copied_to: 'path/to/repo', copied?: true, directory: 'repo'
+          working_copy = double 'working_copy', path_to_local_repo: 'path/to/repo', full_name: 'org/repo', copied_to: 'path/to/repo', copied?: true, directory: 'repo'
           repository.get_instance({'repository' => {'name' => 'foo/book'}},
-                                  vcs_repo: vcs_repo) { |*args| Section.new(*args) }
+                                  working_copy: working_copy) { |*args| Section.new(*args) }
         end
 
         context 'if the repo is not a hash' do
           let(:local_repo_dir) { 'spec/fixtures/repositories' }
           it 'raises a not a hash error message' do
-            vcs_repo = double 'vcs_repo', path_to_local_repo: 'path/to/repo', copied_to: 'path/to/repo'
+            working_copy = double 'working_copy', path_to_local_repo: 'path/to/repo', copied_to: 'path/to/repo'
             expect {
               repository.get_instance({ 'repository' => 'foo/definitely-not-around' },
-                                      vcs_repo: vcs_repo,
+                                      working_copy: working_copy,
                                       destination_dir: local_repo_dir) { |*args| Section.new(*args) }
             }.to raise_error(RuntimeError,
                              "section repository 'foo/definitely-not-around' is not a hash")
@@ -35,10 +35,10 @@ module Bookbinder
         context 'if the repo name is missing' do
           let(:local_repo_dir) { 'spec/fixtures/repositories' }
           it 'raises a missing name key error message' do
-            vcs_repo = double 'vcs_repo', path_to_local_repo: 'path/to/repo', copied_to: 'path/to/repo'
+            working_copy = double 'working_copy', path_to_local_repo: 'path/to/repo', copied_to: 'path/to/repo'
             expect {
               repository.get_instance({ 'repository' => { some_key: 'test' }},
-                                      vcs_repo: vcs_repo,
+                                      working_copy: working_copy,
                                       destination_dir: local_repo_dir) { |*args| Section.new(*args) }
             }.to raise_error(RuntimeError,
                              "section repository '{:some_key=>\"test\"}' missing name key")


### PR DESCRIPTION
We need to stop treating GitHub as a special case. It's not, and this will complicate matters when we want multiple git hosting vendors, or when we want to use git in a more distributed fashion.

Ongoing.