### PR TITLE
Suggested tweaks to Section Repository Ref section

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,12 +185,9 @@ If you specify a `layout_repo:` in `config.yml` with the full name of a GitHub r
 
 ### Section Repository Ref
 
-By default, the `bookbinder bind github` command binds the most current versions of the documents in the GitHub repositories specified by the `sections:` of your `config.yml`.
+By default, the `bookbinder bind github` command binds the most current versions (i.e., the `master` branch) of the documents in the GitHub repositories specified by the `sections:` of your `config.yml`.
 
-To use a previous version of a repo:
-
-1. Add a `ref` key for the repository within your `config.yml`.
-2. Specify the SHA of the previous version as the value of the `ref` key.
+Bookbinder supports a `ref` key to enable use of an alternate version of a repo. The value of this key can be the name of a branch (e.g., `develop`), a SHA, or a tag (`v19`).
 
 Example:
 


### PR DESCRIPTION
Hi! I had totally missed that bookbinder could use a branch when binding from Github.

I suggest you add in a bit of the descriptive text from previous versions of this README.md. I brought a few sentences back, plus I added a few examples from a popular [branching model](http://nvie.com/posts/a-successful-git-branching-model/) that would have been sure to catch my eye when I first scanned the document.

After my changes, the two steps seemed redundant to the example, so I took them out.

I hope my changes seem helpful!

--
  Marco Nicosia
  Product Manager
  Pivotal Software, Inc.