### PR TITLE
Auto preview refactors (feature not implemented yet)

### DIFF
--- a/lib/bookbinder/commands/bind.rb
+++ b/lib/bookbinder/commands/bind.rb
@@ -72,23 +72,27 @@ module Bookbinder
         if file_system_accessor.file_exist?('redirects.rb')
           file_system_accessor.copy('redirects.rb', output_locations.final_app_dir)
         end
-        static_site_generator.run(
+        generation_result = static_site_generator.run(
           output_locations,
           config_decorator.generate(bind_config, sections),
           bind_options.local_repo_dir,
           bind_options.verbose?,
           subnavs(sections)
         )
-        file_system_accessor.copy(output_locations.build_dir, output_locations.public_dir)
-        result = sitemap_writer.write(
-          bind_config.public_host,
-          bind_options.streams,
-          bind_config.broken_link_exclusions
-        )
+        if generation_result.success?
+          file_system_accessor.copy(output_locations.build_dir, output_locations.public_dir)
+          result = sitemap_writer.write(
+            bind_config.public_host,
+            bind_options.streams,
+            bind_config.broken_link_exclusions
+          )
 
-        bind_options.streams[:success].puts "Bookbinder bound your book into #{output_locations.final_app_dir}"
+          bind_options.streams[:success].puts "Bookbinder bound your book into #{output_locations.final_app_dir}"
 
-        result.has_broken_links? ? 1 : 0
+          result.has_broken_links? ? 1 : 0
+        else
+          1
+        end
       end
 
       private

--- a/lib/bookbinder/commands/bind.rb
+++ b/lib/bookbinder/commands/bind.rb
@@ -1,6 +1,5 @@
 require 'middleman-syntax'
 
-require_relative '../config/archive_menu_configuration'
 require_relative '../errors/cli_error'
 require_relative 'bind/bind_options'
 require_relative 'naming'
@@ -70,12 +69,16 @@ module Bookbinder
           options: bind_options.options,
           output_streams: bind_options.streams
         )
-        FileUtils.cp 'redirects.rb', output_locations.final_app_dir if File.exists?('redirects.rb')
-        static_site_generator.run(output_locations,
-                                  config_decorator.generate(bind_config, sections),
-                                  bind_options.local_repo_dir,
-                                  bind_options.verbose?,
-                                  subnavs(sections))
+        if file_system_accessor.file_exist?('redirects.rb')
+          file_system_accessor.copy('redirects.rb', output_locations.final_app_dir)
+        end
+        static_site_generator.run(
+          output_locations,
+          config_decorator.generate(bind_config, sections),
+          bind_options.local_repo_dir,
+          bind_options.verbose?,
+          subnavs(sections)
+        )
         file_system_accessor.copy(output_locations.build_dir, output_locations.public_dir)
         result = sitemap_writer.write(
           bind_config.public_host,

--- a/lib/bookbinder/commands/bind.rb
+++ b/lib/bookbinder/commands/bind.rb
@@ -13,7 +13,7 @@ module Bookbinder
       def initialize(base_streams,
                      output_locations,
                      config_factory,
-                     archive_menu_config,
+                     config_decorator,
                      file_system_accessor,
                      static_site_generator,
                      sitemap_writer,
@@ -24,7 +24,7 @@ module Bookbinder
         @base_streams = base_streams
         @output_locations = output_locations
         @config_factory = config_factory
-        @archive_menu_config = archive_menu_config
+        @config_decorator = config_decorator
         @file_system_accessor = file_system_accessor
         @static_site_generator = static_site_generator
         @sitemap_writer = sitemap_writer
@@ -48,15 +48,10 @@ module Bookbinder
       end
 
       def run(cli_arguments)
-        bind_options = BindComponents::BindOptions.new(cli_arguments, base_streams)
-        bind_options.validate!
-
-        bind_source, *options = cli_arguments
-        bind_config = config_factory.produce(bind_source)
-
-        local_repo_dir = generate_local_repo_dir(context_dir, bind_source)
-        cloner = cloner_factory.produce(local_repo_dir)
-        section_repository = section_repository_factory.produce(cloner)
+        bind_options        = BindComponents::BindOptions.new(cli_arguments, base_streams).tap(&:validate!)
+        bind_config         = config_factory.produce(bind_options.bind_source)
+        cloner              = cloner_factory.produce(bind_options.local_repo_dir)
+        section_repository  = section_repository_factory.produce(cloner)
 
         directory_preparer.prepare_directories(
           bind_config,
@@ -64,40 +59,42 @@ module Bookbinder
           output_locations,
           layout_repo_path(bind_config, cloner)
         )
-
         sections = section_repository.fetch(
           configured_sections: bind_config.sections,
           destination_dir: output_locations.cloned_preprocessing_dir,
           ref_override: bind_options.ref_override
         )
-
         preprocessor.preprocess(
           sections,
           output_locations,
-          options: options,
+          options: bind_options.options,
           output_streams: bind_options.streams
         )
-
-        success = publish(
-          sections.map(&:subnav).reduce({}, :merge),
-          {verbose: options.include?('--verbose')},
-          local_repo_dir,
+        FileUtils.cp 'redirects.rb', output_locations.final_app_dir if File.exists?('redirects.rb')
+        static_site_generator.run(output_locations,
+                                  config_decorator.generate(bind_config, sections),
+                                  bind_options.local_repo_dir,
+                                  bind_options.verbose?,
+                                  subnavs(sections))
+        file_system_accessor.copy(output_locations.build_dir, output_locations.public_dir)
+        result = sitemap_writer.write(
+          bind_config.public_host,
           bind_options.streams,
-          output_locations,
-          archive_menu_config.generate(bind_config, sections),
+          bind_config.broken_link_exclusions
         )
 
-        success ? 0 : 1
+        bind_options.streams[:success].puts "Bookbinder bound your book into #{output_locations.final_app_dir}"
+
+        result.has_broken_links? ? 1 : 0
       end
 
       private
 
       attr_reader(
-        :archive_menu_config,
         :base_streams,
         :cloner_factory,
+        :config_decorator,
         :config_factory,
-        :context_dir,
         :directory_preparer,
         :file_system_accessor,
         :final_app_directory,
@@ -108,31 +105,8 @@ module Bookbinder
         :static_site_generator,
       )
 
-      def publish(subnavs, cli_options, local_repo_dir, streams, output_locations, publish_config)
-        FileUtils.cp 'redirects.rb', output_locations.final_app_dir if File.exists?('redirects.rb')
-
-        host_for_sitemap = publish_config.public_host
-
-        static_site_generator.run(output_locations,
-                                  publish_config,
-                                  local_repo_dir,
-                                  cli_options[:verbose],
-                                  subnavs)
-        file_system_accessor.copy output_locations.build_dir, output_locations.public_dir
-
-        result = sitemap_writer.write(
-          host_for_sitemap,
-          streams,
-          publish_config.broken_link_exclusions
-        )
-
-        streams[:success].puts "Bookbinder bound your book into #{output_locations.final_app_dir}"
-
-        !result.has_broken_links?
-      end
-
-      def generate_local_repo_dir(context_dir, bind_source)
-        File.expand_path('..', context_dir) if bind_source == 'local'
+      def subnavs(sections)
+        sections.map(&:subnav).reduce({}, :merge)
       end
 
       def layout_repo_path(config, cloner)

--- a/lib/bookbinder/commands/bind/bind_options.rb
+++ b/lib/bookbinder/commands/bind/bind_options.rb
@@ -1,5 +1,4 @@
 require_relative '../../sheller'
-require_relative '../../streams/colorized_stream'
 
 module Bookbinder
   module Commands
@@ -14,14 +13,30 @@ module Bookbinder
           raise CliError::InvalidArguments unless arguments_are_valid?
         end
 
+        def bind_source
+          opts.first
+        end
+
+        def local_repo_dir
+          File.expand_path('..') if bind_source == 'local'
+        end
+
+        def options
+          opts[1..-1]
+        end
+
         def ref_override
-          'master' if opts.include?('--ignore-section-refs')
+          'master' if options.include?('--ignore-section-refs')
         end
 
         def streams
           base_streams.merge(
-            out: opts.include?('--verbose') ? base_streams[:out] : Sheller::DevNull.new,
+            out: verbose? ? base_streams[:out] : Sheller::DevNull.new,
           )
+        end
+
+        def verbose?
+          options.include?('--verbose')
         end
 
         private
@@ -29,20 +44,15 @@ module Bookbinder
         attr_accessor :base_streams, :opts
 
         def arguments_are_valid?
-          valid_options = %w(--verbose --ignore-section-refs --dita-flags).to_set
-          %w(local remote github).include?(bind_source) && flag_names.to_set.subset?(valid_options)
+          %w(local remote github).include?(bind_source) && flag_names.subset?(valid_options)
+        end
+
+        def valid_options
+          %w(--verbose --ignore-section-refs --dita-flags).to_set
         end
 
         def flag_names
-          options.map {|o| o.split('=').first}
-        end
-
-        def bind_source
-          opts.first
-        end
-
-        def options
-          opts[1..-1]
+          options.map {|o| o.split('=').first}.to_set
         end
       end
     end

--- a/lib/bookbinder/commands/collection.rb
+++ b/lib/bookbinder/commands/collection.rb
@@ -3,6 +3,7 @@ Dir.glob(File.expand_path('../../commands/*.rb', __FILE__)).each do |command_fil
 end
 
 require_relative '../commands/bind/directory_preparer'
+require_relative '../config/archive_menu_configuration'
 require_relative '../config/bind_config_factory'
 require_relative '../config/fetcher'
 require_relative '../config/remote_yaml_credential_provider'

--- a/lib/bookbinder/commands/collection.rb
+++ b/lib/bookbinder/commands/collection.rb
@@ -61,7 +61,7 @@ module Bookbinder
         @standard_commands ||= [
           Commands::Generate.new(
             local_file_system_accessor,
-            Sheller.new,
+            sheller,
             Dir.pwd,
             streams
           ),
@@ -91,14 +91,14 @@ module Bookbinder
           Config::BindConfigFactory.new(version_control_system, configuration_fetcher),
           Config::ArchiveMenuConfiguration.new(loader: config_loader, config_filename: 'bookbinder.yml'),
           local_file_system_accessor,
-          MiddlemanRunner.new(streams, local_file_system_accessor),
+          MiddlemanRunner.new(streams, local_file_system_accessor, sheller),
           Postprocessing::SitemapWriter.build(logger, final_app_directory, sitemap_port),
           Preprocessing::Preprocessor.new(
             Preprocessing::DitaPreprocessor.new(
               DitaHtmlToMiddlemanFormatter.new(local_file_system_accessor, subnav_formatter, html_document_manipulator),
               local_file_system_accessor,
               DitaCommandCreator.new(ENV['PATH_TO_DITA_OT_LIBRARY']),
-              Sheller.new
+              sheller
             ),
             Preprocessing::LinkToSiteGenDir.new(local_file_system_accessor),
           ),
@@ -152,6 +152,10 @@ module Bookbinder
 
       def local_file_system_accessor
         @local_file_system_accessor ||= LocalFileSystemAccessor.new
+      end
+
+      def sheller
+        @sheller ||= Sheller.new
       end
 
       def sitemap_port

--- a/lib/bookbinder/middleman_runner.rb
+++ b/lib/bookbinder/middleman_runner.rb
@@ -2,48 +2,22 @@ require 'middleman-core'
 require 'middleman-core/cli'
 require 'middleman-core/profiling'
 require 'yaml'
-require_relative 'code_example_reader'
-
-class Middleman::Cli::BuildAction
-  def handle_error(file_name, response, e=Thor::Error.new(response))
-    our_errors = [Bookbinder::CodeExampleReader::InvalidSnippet,
-                  QuicklinksRenderer::BadHeadingLevelError,
-                  Git::GitExecuteError]
-    raise e if our_errors.include?(e.class)
-
-    original_handle_error(e, file_name, response)
-  end
-
-  private
-
-  def original_handle_error(e, file_name, response)
-    base.had_errors = true
-
-    base.say_status :error, file_name, :red
-    if base.debugging
-      raise e
-      exit(1)
-    elsif base.options["verbose"]
-      base.shell.say response, :red
-    end
-  end
-end
 
 module Bookbinder
   class MiddlemanRunner
-    def initialize(streams, fs)
-      @out = streams[:out]
+    def initialize(streams, fs, sheller)
+      @streams = streams
       @fs = fs
+      @sheller = sheller
     end
 
     def run(output_locations,
             config,
             local_repo_dir,
-            verbose,
+            verbosity,
             subnav_templates_by_directory)
-      out.puts "\nRunning middleman...\n\n"
-
-      within(output_locations.master_dir) do
+      streams[:out].puts "\nRunning middleman...\n\n"
+      Dir.chdir(output_locations.master_dir) do
         config = {
           archive_menu: config.archive_menu,
           production_host: config.public_host,
@@ -52,25 +26,22 @@ module Bookbinder
           local_repo_dir: local_repo_dir,
           workspace: output_locations.workspace_dir,
         }
-
         fs.write(to: "bookbinder_config.yml", text: YAML.dump(config))
-
-        Middleman::Cli::Build.new([], {quiet: !verbose}, {}).invoke :build, [], {verbose: verbose}
+        sheller.run_command({'MM_ROOT' => output_locations.master_dir.to_s},
+                            "middleman build #{verbosity_levels[verbosity]}",
+                            streams)
       end
     end
 
     private
 
-    attr_reader :out, :fs
+    attr_reader :streams, :fs, :sheller
 
-    def within(temp_root, &block)
-      Middleman::Cli::Build.instance_variable_set(:@_shared_instance, nil)
-      original_mm_root  = ENV['MM_ROOT']
-      ENV['MM_ROOT']    = temp_root.to_s
-
-      Dir.chdir(temp_root) { block.call }
-
-      ENV['MM_ROOT']    = original_mm_root
+    def verbosity_levels
+      {
+        true => "--verbose",
+        false => "--no-verbose"
+      }
     end
   end
 end

--- a/spec/lib/bookbinder/middleman_runner_spec.rb
+++ b/spec/lib/bookbinder/middleman_runner_spec.rb
@@ -113,8 +113,7 @@ module Bookbinder
         run_middleman
     end
 
-    it "raises an exception if Middleman gives a nonzero exit code" do
-
+    xit "raises an exception if Middleman gives a nonzero exit code" do
     end
   end
 end

--- a/spec/lib/bookbinder/middleman_runner_spec.rb
+++ b/spec/lib/bookbinder/middleman_runner_spec.rb
@@ -1,6 +1,7 @@
 require 'tmpdir'
 require_relative '../../../lib/bookbinder/config/configuration'
 require_relative '../../../lib/bookbinder/middleman_runner'
+require_relative '../../../lib/bookbinder/sheller'
 require_relative '../../../lib/bookbinder/values/output_locations'
 require_relative '../../../lib/bookbinder/values/section'
 require_relative '../../helpers/middleman'
@@ -25,7 +26,9 @@ module Bookbinder
     end
 
     let(:fs) { RecordingFs.new }
-    let(:middleman_runner) { MiddlemanRunner.new({out: StringIO.new}, fs) }
+    let(:sheller) { instance_double('Bookbinder::Sheller') }
+    let(:streams) { { out: StringIO.new, err: StringIO.new } }
+    let(:middleman_runner) { MiddlemanRunner.new(streams, fs, sheller) }
 
     let(:context_dir) { Pathname(Dir.mktmpdir) }
     let(:target_dir_path) { context_dir.join('output', 'master_middleman') }
@@ -63,17 +66,14 @@ module Bookbinder
     end
 
     it 'invokes Middleman in the requested directory' do
-      build_command = expect_to_receive_and_return_real_now(Middleman::Cli::Build, :new, [], {:quiet => !verbose}, {})
-
       working_directory_path = nil
-      allow(build_command).to receive(:invoke) { working_directory_path = `pwd`.strip }
-
+      allow(sheller).to receive(:run_command) { working_directory_path = `pwd`.strip }
       run_middleman
-
       expect(Pathname.new(working_directory_path).realpath).to eq(Pathname.new(target_dir_path).realpath)
     end
 
     it "stores bookbinder config for later consumption by our extension" do
+      allow(sheller).to receive(:run_command)
       run_middleman
       expect(fs.received_to).to eq('bookbinder_config.yml')
       expect(fs.received_text_parsed).to eq(
@@ -86,38 +86,35 @@ module Bookbinder
       )
     end
 
-    it 'builds with middleman and passes the verbose parameter' do
-      build_command = expect_to_receive_and_return_real_now(Middleman::Cli::Build, :new, [], {:quiet => !verbose}, {})
-      expect(build_command).to receive(:invoke).with(:build, [], {:verbose => verbose})
+    context "when verbose output is requested" do
+      let(:verbose) { true }
+      it 'builds with middleman in verbose mode' do
+        expect(sheller).to receive(:run_command).with(anything,
+                                                      "middleman build --verbose",
+                                                      streams)
+        run_middleman
+      end
+    end
 
-      run_middleman
+    context "when verbose output is not requested" do
+      let(:verbose) { false }
+      it 'builds with middleman in no verbose mode' do
+        expect(sheller).to receive(:run_command).with(anything,
+                                                      "middleman build --no-verbose",
+                                                      streams)
+        run_middleman
+      end
     end
 
     it 'sets the MM root for invocation' do
-      build_command = expect_to_receive_and_return_real_now(Middleman::Cli::Build, :new, [], {:quiet => !verbose}, {})
-
-      invocation_mm_root = nil
-      allow(build_command).to receive(:invoke) { invocation_mm_root = ENV['MM_ROOT'] }
-
-      run_middleman
-
-      expect(invocation_mm_root).to eq(target_dir_path.to_s)
+        expect(sheller).to receive(:run_command).with({'MM_ROOT' => context_dir.join('output/master_middleman').to_s},
+                                                      anything,
+                                                      anything)
+        run_middleman
     end
 
-    it 'resets the MM root in cleanup' do
-      build_command = expect_to_receive_and_return_real_now(Middleman::Cli::Build, :new, [], {:quiet => !verbose}, {})
+    it "raises an exception if Middleman gives a nonzero exit code" do
 
-      original_mm_root = ENV['MM_ROOT']
-
-      ENV['MM_ROOT'] = 'anything'
-
-      allow(build_command).to receive(:invoke)
-
-      run_middleman
-
-      expect(ENV['MM_ROOT']).to eq('anything')
-
-      ENV['MM_ROOT'] = original_mm_root
     end
   end
 end

--- a/spec/lib/bookbinder/middleman_runner_spec.rb
+++ b/spec/lib/bookbinder/middleman_runner_spec.rb
@@ -72,6 +72,12 @@ module Bookbinder
       expect(Pathname.new(working_directory_path).realpath).to eq(Pathname.new(target_dir_path).realpath)
     end
 
+    it "returns the sheller's return value" do
+      process_status = double('process status')
+      allow(sheller).to receive(:run_command) { process_status }
+      expect(run_middleman).to eq(process_status)
+    end
+
     it "stores bookbinder config for later consumption by our extension" do
       allow(sheller).to receive(:run_command)
       run_middleman
@@ -111,9 +117,6 @@ module Bookbinder
                                                       anything,
                                                       anything)
         run_middleman
-    end
-
-    xit "raises an exception if Middleman gives a nonzero exit code" do
     end
   end
 end


### PR DESCRIPTION
These refactors switch out the middleman in-process hack for shelling out to the middleman command line. Should make it easier to implement an auto preview server, since that's just another middleman command, and we already have symlinking.