### PR TITLE
template_app/Gemfile*: Allow patch version of Ruby to float

### DIFF
--- a/template_app/Gemfile
+++ b/template_app/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-ruby '2.3.0'
+ruby '~> 2.3.0'
 
 gem 'rack'
 gem 'rack-rewrite'

--- a/template_app/Gemfile.lock
+++ b/template_app/Gemfile.lock
@@ -39,8 +39,5 @@ DEPENDENCIES
   sendgrid-ruby (< 3.0)
   therubyracer
 
-RUBY VERSION
-   ruby 2.3.3
-
 BUNDLED WITH
    1.12.5


### PR DESCRIPTION
This makes it work with the Ruby buildpack, even as the buildpack gets updated and drops support for older Ruby versions due to security vulnerabilities or bug fixes.