### PR TITLE
Automatically generate anchor tags for markdown headings

### DIFF
--- a/master_middleman/config.rb
+++ b/master_middleman/config.rb
@@ -17,7 +17,8 @@ set :markdown, :layout_engine => :erb,
                :tables => true,
                :autolink => true,
                :smartypants => true,
-               :fenced_code_blocks => true
+               :fenced_code_blocks => true,
+               :with_toc_data => true
 
 set :css_dir, 'stylesheets'
 


### PR DESCRIPTION
Without the `with_toc_data` argument, bookbinder does not automatically generate anchor text for markdown headings (like `### Section Title`).

This fixes this problem. I can't spot this causing issues elsewhere in the docs but it'd be great if we could get this merged asap.

@bentarnoff This is related to the open OSBAPI PR ([here](https://github.com/openservicebrokerapi/servicebroker/pull/192#issuecomment-301244805)).

( @avade @duglin )