### PR TITLE
Do not parse emphasis inside of words

### DIFF
--- a/master_middleman/config.rb
+++ b/master_middleman/config.rb
@@ -18,7 +18,8 @@ set :markdown, :layout_engine => :erb,
                :autolink => true,
                :smartypants => true,
                :fenced_code_blocks => true,
-               :with_toc_data => true
+               :with_toc_data => true,
+               :no_intra_emphasis => true
 
 set :css_dir, 'stylesheets'
 


### PR DESCRIPTION
This change adds the `:no_intra_emphasis` option for the markdown renderer (redcarpet) so that it does not parse emphasis inside of words. Strings such as `foo_bar_baz` will not generate `<em>` tags.

This fixes the rendering of the service broker API specification.