### PR TITLE
Improve error handling for unconfigured search

### DIFF
--- a/spec/template_app/lib/search/handler_spec.rb
+++ b/spec/template_app/lib/search/handler_spec.rb
@@ -99,6 +99,15 @@ module Bookbinder::Search
 
         expect(html).not_to include('<script>')
       end
+
+      it 'renders the search page with a warning message' do
+        handler = Handler.new(mock_client_class, {})
+        result = handler.call('QUERY_STRING' => 'q=%3Cunconfigured_search%3E&')
+        html = result.last.first
+
+        expect(html).to include('Search is currently disabled. Please try again later')
+      end
+
     end
 
     describe '#extract_query_params' do
@@ -188,10 +197,10 @@ module Bookbinder::Search
         expect(url).to eq('https://searchly.example.com')
       end
 
-      it 'raises an error when no elastic search is bound' do
+      it 'returns nil when no elastic search is bound' do
         handler = Handler.new
 
-        expect { handler.extract_elasticsearch_url({}) }.to raise_error('No Elasticsearch configured!')
+        expect(handler.extract_elasticsearch_url({})).to be_nil
       end
     end
   end

--- a/template_app/lib/search/query.rb
+++ b/template_app/lib/search/query.rb
@@ -5,9 +5,17 @@ require_relative 'hit'
 module Bookbinder
   module Search
     class Query
-      attr_reader :search_term, :product_name, :product_version, :page_number, :result_list, :result_count, :last_page, :page_window
+      attr_accessor :result_count, :message
+      attr_reader :search_term, :product_name, :product_version, :page_number, :result_list, :last_page, :page_window
 
-      def initialize(params)
+      def self.empty_query(message)
+        new.tap do |q|
+          q.result_count = 0
+          q.message = message
+        end
+      end
+
+      def initialize(params={})
         @search_term = params.fetch('q', '')
         @product_name = params.fetch('product_name', nil)
         @product_version = @product_name && params.fetch('product_version', nil)

--- a/template_app/search-results.html.erb
+++ b/template_app/search-results.html.erb
@@ -11,6 +11,9 @@ end
 %>
 
 <div class="search-results">
+  <% if message %>
+    <p><%= message %></p>
+  <% end %>
   <form method="get">
 
     <% unless product_name.nil? %>


### PR DESCRIPTION
The motivation for this PR was to allow the deployment of the `docs.run.pivotal.io` project to a PWS installation that currently does not have an Elastic Search installation accessible. Furthermore, this particular PWS installation does not allow network calls out to the public Internet. Disabling elastic search from the `config.yml` results in a Search UI that executes a Google Custom search.

In order to provide a better UX, I this PR contains the following feature changes:

```
Given that no Elastic Search URL has been provided:
As a User, when I execute a search through the UI
Then I should be on a Search Results page with 0 Results
And I should see a warning message:
"Search is currently disabled. Please try again later"
```
<img width="1364" alt="screen shot 2018-04-27 at 10 28 33 am" src="https://user-images.githubusercontent.com/38972/39376241-d11d1180-4a05-11e8-924f-9069517c26cc.png">

The current behavior for an unconfigured Elastic Search service is that a user ends up on the blank page with the message "An error has occurred"