### PR TITLE
Support fuzzy match code snippet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tags
 bin
 spec/utilities
 vendor/
+.idea

--- a/bookbinder.gemspec
+++ b/bookbinder.gemspec
@@ -42,4 +42,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sinatra', '1.4.8'
   s.add_development_dependency 'jasmine'
   s.add_development_dependency 'rack-test'
+  s.add_development_dependency 'fakefs'
 end

--- a/lib/bookbinder/ingest/missing_working_copy.rb
+++ b/lib/bookbinder/ingest/missing_working_copy.rb
@@ -12,7 +12,7 @@ module Bookbinder
       end
 
       def path
-        Pathname(@source_dir)
+        @source_dir
       end
 
       def ref

--- a/spec/lib/bookbinder/ingest/local_filesystem_cloner_spec.rb
+++ b/spec/lib/bookbinder/ingest/local_filesystem_cloner_spec.rb
@@ -1,57 +1,56 @@
 require_relative '../../../../lib/bookbinder/ingest/local_filesystem_cloner'
-require_relative '../../../helpers/fake_filesystem_accessor'
+require_relative '../../../../lib/bookbinder/local_filesystem_accessor'
+
+require 'tmpdir'
+require 'fileutils'
+require 'pp'
+require 'fakefs/spec_helpers'
 
 module Bookbinder
   module Ingest
     describe LocalFilesystemCloner do
+      include FakeFS::SpecHelpers
+
+      let(:user_repo_dir) { "/my/repo/dir" }
+      let(:fs) { LocalFilesystemAccessor.new }
+
+      def user_repo_mkdir(name)
+        FileUtils.mkdir_p(File.join(user_repo_dir, name))
+      end
+
       context "when the local repo is present" do
         it "logs the fact that it's cloning" do
-          fs = double('filesystem')
           out = StringIO.new
 
-          allow(fs).to receive(:file_exist?).
-            with(Pathname("/my/repo/dir/myrepo")) { true }
-          allow(fs).to receive(:file_exist?).
-            with(Pathname("/my/dest/myrepo")) { false }
+          user_repo_mkdir('myrepo')
           allow(fs).to receive(:link_creating_intermediate_dirs)
 
-          cloner = LocalFilesystemCloner.new({out: out}, fs, "/my/repo/dir")
+          cloner = LocalFilesystemCloner.new({out: out}, fs, user_repo_dir)
           cloner.call(source_repo_name: "myorg/myrepo",
                       destination_parent_dir: "/my/dest")
-          expect(out.tap(&:rewind).read).to match(%r{ copying.*/my/repo/dir})
+          expect(out.string).to match(%r{ copying.*/my/repo/dir})
         end
 
         it "links the repo to the destination" do
-          fs = double('filesystem')
-
-          allow(fs).to receive(:file_exist?).
-            with(Pathname("/my/repo/dir/myrepo")) { true }
-          allow(fs).to receive(:file_exist?).
-            with(Pathname("/destination/dir/myrepo")) { false }
-
-          expect(fs).to receive(:link_creating_intermediate_dirs).
+          user_repo_mkdir('myrepo')
+          allow(fs).to receive(:link_creating_intermediate_dirs).
             with(Pathname("/my/repo/dir/myrepo"),
                  Pathname("/destination/dir/myrepo"))
 
-          cloner = LocalFilesystemCloner.new({out: StringIO.new}, fs, "/my/repo/dir")
+          cloner = LocalFilesystemCloner.new({out: StringIO.new}, fs, user_repo_dir)
           cloner.call(source_repo_name: "myorg/myrepo",
                       destination_parent_dir: "/destination/dir")
         end
 
         context "when destination directory name is set" do
           it "copies the repo to the custom directory" do
-            fs = double('filesystem')
-
-            allow(fs).to receive(:file_exist?).
-              with(Pathname("/sourceparent/sourcerepo")) { true }
-            allow(fs).to receive(:file_exist?).
-              with(Pathname("/destparent/mycustomdestrepo")) { false }
+            user_repo_mkdir('sourcerepo')
 
             expect(fs).to receive(:link_creating_intermediate_dirs).
-              with(Pathname("/sourceparent/sourcerepo"),
+              with(Pathname("/my/repo/dir/sourcerepo"),
                    Pathname("/destparent/mycustomdestrepo"))
 
-            cloner = LocalFilesystemCloner.new({out: StringIO.new}, fs, "/sourceparent")
+            cloner = LocalFilesystemCloner.new({out: StringIO.new}, fs, user_repo_dir)
             cloner.call(source_repo_name: "myorg/sourcerepo",
                         destination_dir_name: 'mycustomdestrepo',
                         destination_parent_dir: "/destparent")
@@ -59,15 +58,10 @@ module Bookbinder
         end
 
         it "returns an object that is has the correct destination" do
-          fs = double('filesystem')
-
-          allow(fs).to receive(:file_exist?).
-            with(Pathname("/my/repo/dir/myrepo")) { true }
-          allow(fs).to receive(:file_exist?).
-            with(Pathname("/destination/dir/myrepo")) { false }
+          user_repo_mkdir('myrepo')
           allow(fs).to receive(:link_creating_intermediate_dirs)
 
-          cloner = LocalFilesystemCloner.new({out: StringIO.new}, fs, "/my/repo/dir")
+          cloner = LocalFilesystemCloner.new({out: StringIO.new}, fs, user_repo_dir)
           result = cloner.call(source_repo_name: "myorg/myrepo",
                                destination_parent_dir: "/destination/dir")
 
@@ -77,28 +71,25 @@ module Bookbinder
 
       context "when the local repo isn't present" do
         it "logs the fact that it isn't copying anything, and doesn't copy" do
-          fs = double('filesystem', file_exist?: false)
           out = StringIO.new
-          cloner = LocalFilesystemCloner.new({out: out}, fs, "/my/repo/dir")
+          cloner = LocalFilesystemCloner.new({out: out}, fs, user_repo_dir)
           result = cloner.call(source_repo_name: "myorg/myrepo",
                                destination_parent_dir: "/some/dest")
           expect(result.path).not_to exist
           expect(result).not_to be_available
           expect(result.full_name).to eq('myorg/myrepo')
-          expect(out.tap(&:rewind).read).to match(%r{ skipping .*/my/repo/dir})
+          expect(out.string).to match(%r{ skipping .*/my/repo/dir})
         end
       end
 
       context 'when the local repo directory name includes the ref' do
         it 'links to the correct file' do
-          fs = FakeFilesystemAccessor.new({
-            "user_repo_dir" => {
-              "repo-ref" => {}
-            },
-            "destination" => {}
-          })
+          user_repo_mkdir("repo-ref")
+          user_repo_mkdir("repo-myorg-ref")
+          FileUtils.mkdir_p("/destination")
+
           out = StringIO.new
-          cloner = LocalFilesystemCloner.new({out: out}, fs, "/user_repo_dir")
+          cloner = LocalFilesystemCloner.new({out: out}, fs, user_repo_dir)
 
           result = cloner.call(source_repo_name: "myorg/repo",
                                source_ref: "ref",
@@ -106,19 +97,16 @@ module Bookbinder
                                destination_dir_name: "reps")
 
           expect(fs.file_exist?(result.path)).to be true
-          expect(out.tap(&:rewind).read).to match(%r{ copying\s*/user_repo_dir/repo-ref})
+          expect(out.string).to match(%r{ copying\s*/my/repo/dir/repo-ref})
         end
 
         context 'and does not have a specific name' do
           it 'links to the folder with the org in it' do
-            fs = FakeFilesystemAccessor.new({
-              "user_repo_dir" => {
-                "docs-org-name-ruff" => {}
-              },
-              "destination" => {}
-            })
+            user_repo_mkdir("docs-org-name-ruff")
+            FileUtils.mkdir_p("/destination")
+
             out = StringIO.new
-            cloner = LocalFilesystemCloner.new({out: out}, fs, "/user_repo_dir")
+            cloner = LocalFilesystemCloner.new({out: out}, fs, user_repo_dir)
 
             result = cloner.call(source_repo_name: "org-name/docs",
                                  source_ref: "ruff",
@@ -126,8 +114,36 @@ module Bookbinder
                                  destination_dir_name: "reps")
 
             expect(fs.file_exist?(result.path)).to be true
-            expect(out.tap(&:rewind).read).to match(%r{ copying\s*/user_repo_dir/docs-org-name-ruff})
+            expect(out.string).to match(%r{ copying\s*/my/repo/dir/docs-org-name-ruff})
           end
+        end
+
+        it 'gives priority to ref/org directory names' do
+          user_repo_mkdir("repo-sm")
+          user_repo_mkdir("repo-myorg-ref")
+
+
+          FileUtils.mkdir_p("/destination")
+
+          out = StringIO.new
+          cloner = LocalFilesystemCloner.new({out: out}, fs, user_repo_dir)
+
+          result = cloner.call(source_repo_name: "myorg/repo",
+                               source_ref: "ref",
+                               destination_parent_dir: "/destination",
+                               destination_dir_name: "reps")
+
+          expect(fs.file_exist?(result.path)).to be true
+          expect(out.string).to match(%r{ copying\s*/my/repo/dir/repo-myorg-ref})
+
+          user_repo_mkdir("repo-ref")
+
+          result = cloner.call(source_repo_name: "myorg/repo",
+                               source_ref: "ref",
+                               destination_parent_dir: "/destination",
+                               destination_dir_name: "reps")
+
+          expect(out.string).to match(%r{ copying\s*/my/repo/dir/repo-ref})
         end
       end
     end


### PR DESCRIPTION

support fuzzy matching of directories when using non `master` directory structure

The current workflow for `yield_for_code_snippet` assumes all snippets are always in the `master` branch.
The lookup path for the snippet directory would be (in order):
- repo-name
- repo-name-branch-name
- repo-name-org-name-branch-name

When we moved from `master` to `develop`/`release` pattern, our document generation starting failing in the Concourse pipeline.
This is because our input name was `platform-automation-develop` instead of the assumed `platform-automation-master` as noted above.

This change supports the fact that inputs (from the generated pipeline), do not support that format.
It will perform precedence lookup, as above, and then do a _best match_ for a directory.
This means that our workflow of `develop`/`release` will be supported and we do not break existing `master` patterns.
[#161320648]
