### PR TITLE
Add a new function in support of product variables: set_title_no_spaces

### DIFF
--- a/master_middleman/bookbinder_helpers.rb
+++ b/master_middleman/bookbinder_helpers.rb
@@ -119,6 +119,10 @@ module Bookbinder
         current_page.data.title= args.join(' ')
       end
 
+      def set_title_no_spaces(*args)
+        current_page.data.title= args.join
+      end
+
       def product_info
         config[:product_info].fetch(template_key, {})
       end


### PR DESCRIPTION
Geode/GemFire docs need a version of 'set_title' that concatenates strings without adding spaces between them.